### PR TITLE
Update renovate configuration to extract version from GitHub tags.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,7 +27,8 @@
       "fileMatch": [".pulumi.version"],
       "matchStrings": ["(?<currentValue>\\S+)"],
       "depNameTemplate": "pulumi/pulumi",
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
- Updated renovate configuration to include extracting version from GitHub tags using a regex pattern.
