### PR TITLE
Updated archive and binary installation functions

### DIFF
--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/archiveInstall.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/archiveInstall.ts
@@ -55,6 +55,7 @@ export function archiveInstall<T extends ReadonlyArray<string>>(
       gzip: true,
       stripComponents: args.stripComponents,
     },
+    triggers: [args.url],
   }, { parent, dependsOn: download });
 
   // Ensure directory exists
@@ -75,6 +76,7 @@ export function archiveInstall<T extends ReadonlyArray<string>>(
         dest: interpolate`${directory}/${k}`,
       },
       delete: interpolate`rm -f ${directory}/${k}`,
+      triggers: [args.url],
     }, { parent, dependsOn: [tar, mkdir] })
   }), {} as Maps<T, Mv>);
 

--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/binaryInstall.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/binaryInstall.ts
@@ -50,6 +50,7 @@ export function binaryInstall(name: string, args: BinaryInstallArgs, parent: Res
       dest: binPath,
     },
     delete: interpolate`rm -rf ${binPath}`,
+    triggers: [args.url],
   }, { parent, dependsOn: [download, mkdir] });
 
   const rm = new Rm(name, {


### PR DESCRIPTION
Added 'triggers' property to the archiveInstall and binaryInstall functions. This ensures that changes in the URL trigger a re-installation, keeping the installations up-to-date with their respective sources.
