### PR TITLE
Updated runcInstall.ts with chmod functionality

### DIFF
--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/runcInstall.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/runcInstall.ts
@@ -1,5 +1,6 @@
 import { ComponentResourceOptions, interpolate, output } from '@pulumi/pulumi';
 import * as schema from '../schema-types';
+import { Chmod } from '../tools';
 import { binaryInstall } from './binaryInstall';
 
 export class RuncInstall extends schema.RuncInstall {
@@ -21,6 +22,14 @@ export class RuncInstall extends schema.RuncInstall {
       url,
       finalBin: 'runc',
     }, this);
+
+    const chmod = new Chmod(name, {
+      connection,
+      create: {
+        files: [path],
+        mode: '+x',
+      },
+    }, { parent: this, dependsOn: mv });
 
     this.architecture = architecture;
     this.connection = connection;


### PR DESCRIPTION
The runcInstall.ts file has been updated to include the Chmod class. This new addition allows for changing the mode of files, specifically making them executable. The change is dependent on the 'mv' operation and is implemented as a parent-child relationship for better organization and readability.
