### PR TITLE
Updated default containerd version and binaries list

### DIFF
--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/archiveInstall.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/archiveInstall.ts
@@ -36,6 +36,7 @@ export function archiveInstall<T extends ReadonlyArray<string>>(
   const mktemp = new Mktemp(name, {
     connection,
     create: { directory: true },
+    triggers: [url],
   }, { parent });
 
   const tmpDir = mktemp.stdout;
@@ -91,6 +92,7 @@ export function archiveInstall<T extends ReadonlyArray<string>>(
       force: true,
       recursive: true,
     },
+    triggers: [mktemp],
   }, { parent, dependsOn: Object.values(mvs) });
 
   return { download, mkdir, mktemp, mvs, paths, rm, tar };

--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/binaryInstall.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/binaryInstall.ts
@@ -24,6 +24,7 @@ export function binaryInstall(name: string, args: BinaryInstallArgs, parent: Res
   const mktemp = new Mktemp(name, {
     connection: args.connection,
     create: { directory: true },
+    triggers: [args.url],
   }, { parent });
 
   const tmpDir = mktemp.stdout;
@@ -63,6 +64,7 @@ export function binaryInstall(name: string, args: BinaryInstallArgs, parent: Res
       force: true,
       recursive: true,
     },
+    triggers: [mktemp],
   }, { parent, dependsOn: mv });
 
   return { mktemp, download, mkdir, mv, path: binPath, rm };

--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/containerdInstall.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/remote/containerdInstall.ts
@@ -10,7 +10,7 @@ export class ContainerdInstall extends schema.ContainerdInstall {
     const architecture = output(args.architecture ?? 'amd64');
     const connection = output(args.connection);
     const directory = output(args.directory ?? '/bin');
-    const version = output(args.version ?? '1.4.4'); // TODO: Stateful versioning?
+    const version = output(args.version ?? '1.7.19'); // TODO: Stateful versioning?
     const archiveName = interpolate`containerd-${version}-linux-${architecture}.tar.gz`;
     const url = interpolate`https://github.com/containerd/containerd/releases/download/v${version}/${archiveName}`;
 
@@ -20,7 +20,14 @@ export class ContainerdInstall extends schema.ContainerdInstall {
 
     const install = archiveInstall(name, {
       archiveName,
-      binaries: ['containerd'] as const,
+      binaries: [
+        'containerd',
+        'containerd-shim',
+        'containerd-shim-runc-v1',
+        'containerd-shim-runc-v2',
+        'containerd-stress',
+        'ctr',
+      ] as const,
       connection,
       directory,
       stripComponents: 1,


### PR DESCRIPTION
The default version of containerd has been updated from '1.4.4' to '1.7.19'. Additionally, the list of binaries for installation has been expanded to include 'containerd-shim', 'containerd-shim-runc-v1', 'containerd-shim-runc-v2', 'containerd-stress', and 'ctr'.
