### PR TITLE
Added 'now' option to systemctl tool

### DIFF
--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/schema-types.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/schema-types.ts
@@ -2022,11 +2022,13 @@ export type SystemctlCommandInputs = "bind" | "cat" | "clean" | "daemon-reload" 
 export type SystemctlCommandOutputs = "bind" | "cat" | "clean" | "daemon-reload" | "disable" | "enable" | "freeze" | "is-active" | "is-enabled" | "is-failed" | "isolate" | "kill" | "list-automounts" | "list-dependencies" | "list-paths" | "list-sockets" | "list-timers" | "list-units" | "mask" | "mount-image" | "reenable" | "reload" | "reload-or-restart" | "restart" | "set-property" | "show" | "start" | "status" | "stop" | "thaw" | "try-reload-or-restart" | "try-restart" | "unmask";
 export interface SystemctlOptsInputs {
     readonly command: SystemctlCommandInputs;
+    readonly now?: pulumi.Input<boolean>;
     readonly pattern?: pulumi.Input<string>;
     readonly unit?: pulumi.Input<string>;
 }
 export interface SystemctlOptsOutputs {
     readonly command: SystemctlCommandOutputs;
+    readonly now?: pulumi.Output<boolean>;
     readonly pattern?: pulumi.Output<string>;
     readonly unit?: pulumi.Output<string>;
 }

--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/schema.json
@@ -1826,6 +1826,10 @@
                     "plain": true,
                     "description": "Corresponds to the COMMAND argument."
                 },
+                "now": {
+                    "type": "boolean",
+                    "description": "Corresponds to the `--now` option."
+                },
                 "pattern": {
                     "type": "string",
                     "description": "Corresponds to the [PATTERN] argument"

--- a/provider/cmd/pulumi-resource-kubernetes-the-hard-way/tools/systemctl.ts
+++ b/provider/cmd/pulumi-resource-kubernetes-the-hard-way/tools/systemctl.ts
@@ -1,4 +1,4 @@
-import { ComponentResourceOptions, output } from '@pulumi/pulumi';
+import { ComponentResourceOptions } from '@pulumi/pulumi';
 import * as schema from '../schema-types';
 import * as tool from './tool';
 
@@ -12,15 +12,16 @@ const apply = tool.factory<
 
     // TODO: Little bit smarter check here
     if (opts.command !== 'daemon-reload') {
-      builder.arg(opts.unit);
+      b.arg(opts.unit);
     }
 
-    return b;
+    return b.option('--now', opts.now);
   },
   (i) => ({
     command: i.command,
     unit: tool.mapO(i.unit),
     pattern: tool.mapO(i.pattern),
+    now: tool.mapO(i.now),
   }),
 );
 

--- a/schemagen/pkg/gen/tools/systemctl.go
+++ b/schemagen/pkg/gen/tools/systemctl.go
@@ -17,6 +17,7 @@ func generateSystemctl() tool {
 		},
 		"pattern": props.String("Corresponds to the [PATTERN] argument"),
 		"unit":    props.String("Corresponds to the [UNIT...] argument."),
+		"now":     props.Boolean("Corresponds to the `--now` option."),
 	}
 
 	required := []string{"command"}

--- a/sdk/dotnet/Tools/Inputs/SystemctlOptsArgs.cs
+++ b/sdk/dotnet/Tools/Inputs/SystemctlOptsArgs.cs
@@ -23,6 +23,12 @@ namespace UnMango.KubernetesTheHardWay.Tools.Inputs
         public UnMango.KubernetesTheHardWay.Tools.SystemctlCommand Command { get; set; }
 
         /// <summary>
+        /// Corresponds to the `--now` option.
+        /// </summary>
+        [Input("now")]
+        public Input<bool>? Now { get; set; }
+
+        /// <summary>
         /// Corresponds to the [PATTERN] argument
         /// </summary>
         [Input("pattern")]

--- a/sdk/dotnet/Tools/Outputs/SystemctlOpts.cs
+++ b/sdk/dotnet/Tools/Outputs/SystemctlOpts.cs
@@ -22,6 +22,10 @@ namespace UnMango.KubernetesTheHardWay.Tools.Outputs
         /// </summary>
         public readonly UnMango.KubernetesTheHardWay.Tools.SystemctlCommand Command;
         /// <summary>
+        /// Corresponds to the `--now` option.
+        /// </summary>
+        public readonly bool? Now;
+        /// <summary>
         /// Corresponds to the [PATTERN] argument
         /// </summary>
         public readonly string? Pattern;
@@ -34,11 +38,14 @@ namespace UnMango.KubernetesTheHardWay.Tools.Outputs
         private SystemctlOpts(
             UnMango.KubernetesTheHardWay.Tools.SystemctlCommand command,
 
+            bool? now,
+
             string? pattern,
 
             string? unit)
         {
             Command = command;
+            Now = now;
             Pattern = pattern;
             Unit = unit;
         }

--- a/sdk/go/kubernetes-the-hard-way/tools/pulumiTypes.go
+++ b/sdk/go/kubernetes-the-hard-way/tools/pulumiTypes.go
@@ -2391,6 +2391,8 @@ func (o SedOptsPtrOutput) Version() pulumi.BoolPtrOutput {
 type SystemctlOpts struct {
 	// Corresponds to the COMMAND argument.
 	Command SystemctlCommand `pulumi:"command"`
+	// Corresponds to the `--now` option.
+	Now *bool `pulumi:"now"`
 	// Corresponds to the [PATTERN] argument
 	Pattern *string `pulumi:"pattern"`
 	// Corresponds to the [UNIT...] argument.
@@ -2412,6 +2414,8 @@ type SystemctlOptsInput interface {
 type SystemctlOptsArgs struct {
 	// Corresponds to the COMMAND argument.
 	Command SystemctlCommand `pulumi:"command"`
+	// Corresponds to the `--now` option.
+	Now pulumi.BoolPtrInput `pulumi:"now"`
 	// Corresponds to the [PATTERN] argument
 	Pattern pulumi.StringPtrInput `pulumi:"pattern"`
 	// Corresponds to the [UNIT...] argument.
@@ -2501,6 +2505,11 @@ func (o SystemctlOptsOutput) Command() SystemctlCommandOutput {
 	return o.ApplyT(func(v SystemctlOpts) SystemctlCommand { return v.Command }).(SystemctlCommandOutput)
 }
 
+// Corresponds to the `--now` option.
+func (o SystemctlOptsOutput) Now() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v SystemctlOpts) *bool { return v.Now }).(pulumi.BoolPtrOutput)
+}
+
 // Corresponds to the [PATTERN] argument
 func (o SystemctlOptsOutput) Pattern() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SystemctlOpts) *string { return v.Pattern }).(pulumi.StringPtrOutput)
@@ -2543,6 +2552,16 @@ func (o SystemctlOptsPtrOutput) Command() SystemctlCommandPtrOutput {
 		}
 		return &v.Command
 	}).(SystemctlCommandPtrOutput)
+}
+
+// Corresponds to the `--now` option.
+func (o SystemctlOptsPtrOutput) Now() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *SystemctlOpts) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Now
+	}).(pulumi.BoolPtrOutput)
 }
 
 // Corresponds to the [PATTERN] argument

--- a/sdk/java/src/main/java/com/unmango/kubernetesthehardway/tools/inputs/SystemctlOptsArgs.java
+++ b/sdk/java/src/main/java/com/unmango/kubernetesthehardway/tools/inputs/SystemctlOptsArgs.java
@@ -7,6 +7,7 @@ import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import com.unmango.kubernetesthehardway.tools.enums.SystemctlCommand;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -34,6 +35,21 @@ public final class SystemctlOptsArgs extends com.pulumi.resources.ResourceArgs {
      */
     public SystemctlCommand command() {
         return this.command;
+    }
+
+    /**
+     * Corresponds to the `--now` option.
+     * 
+     */
+    @Import(name="now")
+    private @Nullable Output<Boolean> now;
+
+    /**
+     * @return Corresponds to the `--now` option.
+     * 
+     */
+    public Optional<Output<Boolean>> now() {
+        return Optional.ofNullable(this.now);
     }
 
     /**
@@ -70,6 +86,7 @@ public final class SystemctlOptsArgs extends com.pulumi.resources.ResourceArgs {
 
     private SystemctlOptsArgs(SystemctlOptsArgs $) {
         this.command = $.command;
+        this.now = $.now;
         this.pattern = $.pattern;
         this.unit = $.unit;
     }
@@ -101,6 +118,27 @@ public final class SystemctlOptsArgs extends com.pulumi.resources.ResourceArgs {
         public Builder command(SystemctlCommand command) {
             $.command = command;
             return this;
+        }
+
+        /**
+         * @param now Corresponds to the `--now` option.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder now(@Nullable Output<Boolean> now) {
+            $.now = now;
+            return this;
+        }
+
+        /**
+         * @param now Corresponds to the `--now` option.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder now(Boolean now) {
+            return now(Output.of(now));
         }
 
         /**

--- a/sdk/java/src/main/java/com/unmango/kubernetesthehardway/tools/outputs/SystemctlOpts.java
+++ b/sdk/java/src/main/java/com/unmango/kubernetesthehardway/tools/outputs/SystemctlOpts.java
@@ -6,6 +6,7 @@ package com.unmango.kubernetesthehardway.tools.outputs;
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import com.unmango.kubernetesthehardway.tools.enums.SystemctlCommand;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -18,6 +19,11 @@ public final class SystemctlOpts {
      * 
      */
     private SystemctlCommand command;
+    /**
+     * @return Corresponds to the `--now` option.
+     * 
+     */
+    private @Nullable Boolean now;
     /**
      * @return Corresponds to the [PATTERN] argument
      * 
@@ -36,6 +42,13 @@ public final class SystemctlOpts {
      */
     public SystemctlCommand command() {
         return this.command;
+    }
+    /**
+     * @return Corresponds to the `--now` option.
+     * 
+     */
+    public Optional<Boolean> now() {
+        return Optional.ofNullable(this.now);
     }
     /**
      * @return Corresponds to the [PATTERN] argument
@@ -62,12 +75,14 @@ public final class SystemctlOpts {
     @CustomType.Builder
     public static final class Builder {
         private SystemctlCommand command;
+        private @Nullable Boolean now;
         private @Nullable String pattern;
         private @Nullable String unit;
         public Builder() {}
         public Builder(SystemctlOpts defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.command = defaults.command;
+    	      this.now = defaults.now;
     	      this.pattern = defaults.pattern;
     	      this.unit = defaults.unit;
         }
@@ -78,6 +93,12 @@ public final class SystemctlOpts {
               throw new MissingRequiredPropertyException("SystemctlOpts", "command");
             }
             this.command = command;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder now(@Nullable Boolean now) {
+
+            this.now = now;
             return this;
         }
         @CustomType.Setter
@@ -95,6 +116,7 @@ public final class SystemctlOpts {
         public SystemctlOpts build() {
             final var _resultValue = new SystemctlOpts();
             _resultValue.command = command;
+            _resultValue.now = now;
             _resultValue.pattern = pattern;
             _resultValue.unit = unit;
             return _resultValue;

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -1249,6 +1249,10 @@ export namespace tools {
          */
         command: enums.tools.SystemctlCommand;
         /**
+         * Corresponds to the `--now` option.
+         */
+        now?: pulumi.Input<boolean>;
+        /**
          * Corresponds to the [PATTERN] argument
          */
         pattern?: pulumi.Input<string>;

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -1264,6 +1264,10 @@ export namespace tools {
          */
         command: enums.tools.SystemctlCommand;
         /**
+         * Corresponds to the `--now` option.
+         */
+        now?: boolean;
+        /**
          * Corresponds to the [PATTERN] argument
          */
         pattern?: string;

--- a/sdk/python/pulumi_kubernetes_the_hard_way/tools/_inputs.py
+++ b/sdk/python/pulumi_kubernetes_the_hard_way/tools/_inputs.py
@@ -1270,15 +1270,19 @@ class SedOptsArgs:
 class SystemctlOptsArgs:
     def __init__(__self__, *,
                  command: 'SystemctlCommand',
+                 now: Optional[pulumi.Input[bool]] = None,
                  pattern: Optional[pulumi.Input[str]] = None,
                  unit: Optional[pulumi.Input[str]] = None):
         """
         Abstraction over the `systemctl` utility on a remote system.
         :param 'SystemctlCommand' command: Corresponds to the COMMAND argument.
+        :param pulumi.Input[bool] now: Corresponds to the `--now` option.
         :param pulumi.Input[str] pattern: Corresponds to the [PATTERN] argument
         :param pulumi.Input[str] unit: Corresponds to the [UNIT...] argument.
         """
         pulumi.set(__self__, "command", command)
+        if now is not None:
+            pulumi.set(__self__, "now", now)
         if pattern is not None:
             pulumi.set(__self__, "pattern", pattern)
         if unit is not None:
@@ -1295,6 +1299,18 @@ class SystemctlOptsArgs:
     @command.setter
     def command(self, value: 'SystemctlCommand'):
         pulumi.set(self, "command", value)
+
+    @property
+    @pulumi.getter
+    def now(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Corresponds to the `--now` option.
+        """
+        return pulumi.get(self, "now")
+
+    @now.setter
+    def now(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "now", value)
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumi_kubernetes_the_hard_way/tools/outputs.py
+++ b/sdk/python/pulumi_kubernetes_the_hard_way/tools/outputs.py
@@ -1155,15 +1155,19 @@ class SystemctlOpts(dict):
     """
     def __init__(__self__, *,
                  command: 'SystemctlCommand',
+                 now: Optional[bool] = None,
                  pattern: Optional[str] = None,
                  unit: Optional[str] = None):
         """
         Abstraction over the `systemctl` utility on a remote system.
         :param 'SystemctlCommand' command: Corresponds to the COMMAND argument.
+        :param bool now: Corresponds to the `--now` option.
         :param str pattern: Corresponds to the [PATTERN] argument
         :param str unit: Corresponds to the [UNIT...] argument.
         """
         pulumi.set(__self__, "command", command)
+        if now is not None:
+            pulumi.set(__self__, "now", now)
         if pattern is not None:
             pulumi.set(__self__, "pattern", pattern)
         if unit is not None:
@@ -1176,6 +1180,14 @@ class SystemctlOpts(dict):
         Corresponds to the COMMAND argument.
         """
         return pulumi.get(self, "command")
+
+    @property
+    @pulumi.getter
+    def now(self) -> Optional[bool]:
+        """
+        Corresponds to the `--now` option.
+        """
+        return pulumi.get(self, "now")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
A new property, 'now', has been added to the systemctl tool. This corresponds to the '--now' option in the command line interface.
